### PR TITLE
Modified HBT to write the most bound particle ID as a separate dataset.

### DIFF
--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -72,6 +72,7 @@ void SubhaloSnapshot_t::BuildHDFDataType()
 
   InsertMember(ComovingMostBoundPosition, H5T_HBTxyz);
   InsertMember(PhysicalMostBoundVelocity, H5T_HBTxyz);
+  InsertMember(MostBoundParticleID, H5T_HBTInt);
   InsertMember(ComovingAveragePosition, H5T_HBTxyz);
   InsertMember(PhysicalAverageVelocity, H5T_HBTxyz);
   

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -170,7 +170,7 @@ RegisterAttr(PhysicalAverageVelocity[0], MPI_HBT_REAL, 3)
 RegisterAttr(ComovingMostBoundPosition[0], MPI_HBT_REAL, 3)
 RegisterAttr(PhysicalMostBoundVelocity[0], MPI_HBT_REAL, 3)
 assert(offsets[NumAttr-1]-offsets[NumAttr-2]==sizeof(HBTReal)*3);//to make sure HBTxyz is stored locally.
-
+RegisterAttr(MostBoundParticleID, MPI_HBT_INT, 1)
 RegisterAttr(SinkTrackId, MPI_HBT_INT, 1)
 #undef RegisterAttr
 assert(NumAttr<=MaxNumAttr);

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -79,6 +79,7 @@ public:
   HBTxyz PhysicalAverageVelocity;//default vel of sub
   HBTxyz ComovingMostBoundPosition;//default pos of sub
   HBTxyz PhysicalMostBoundVelocity;
+  HBTInt MostBoundParticleID;
 
   //for merging  
   HBTInt SinkTrackId; //the trackId it sinked to, -1 if it hasn't sunk.
@@ -103,6 +104,7 @@ public:
 	SnapshotIndexOfBirth=SpecialConst::NullSnapshotId;
 	SnapshotIndexOfDeath=SpecialConst::NullSnapshotId;
 	SinkTrackId=SpecialConst::NullTrackId;
+	MostBoundParticleID=SpecialConst::NullParticleId;
   }
   void Unbind(const Snapshot_t &epoch);
   void RecursiveUnbind(SubhaloList_t &Subhalos, const Snapshot_t &snap);

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -270,6 +270,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   {
     Nbound=0;
     Mbound=0.;
+    MostBoundParticleID = SpecialConst::NullParticleId;
 #ifdef SAVE_BINDING_ENERGY
 	Energies.clear();
 #endif
@@ -279,6 +280,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   {
 	Nbound=1;
 	Mbound=Particles[0].Mass;
+	MostBoundParticleID = Particles[0].Id;
 #ifdef SAVE_BINDING_ENERGY
 	Energies.resize(1);
 	Energies[0]=0.;
@@ -416,6 +418,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 	for(HBTInt i=0;i<Nbound;i++)
 	  Energies[i]=Elist[i].E;
 #endif
+	MostBoundParticleID = Particles[0].Id;
 }
 void Subhalo_t::RecursiveUnbind(SubhaloList_t &Subhalos, const Snapshot_t &snap)
 {


### PR DESCRIPTION
HDF5 doesn't allow partial I/O on variable length types, so to get the
most bound particle for each subhalo all of the IDs must be
read. This is slower and more memory intensive than just reading the
subhalo catalogue.

This change adds the most bound particle ID to the subhalo struct 
and the corresponding HDF5 and MPI data types. The most bound particle
ID is updated whenever unbinding is done. This should make it easier to run
Galform on HBT output.
