### PR TITLE
Prevent crash on shutdown due to MPI call after MPI_Finalize

### DIFF
--- a/src/halo.h
+++ b/src/halo.h
@@ -10,6 +10,8 @@
 #include "datatypes.h"
 #include "snapshot_number.h"
 #include "snapshot.h"
+#include "mpi_wrapper.h"
+
 class Halo_t
 {
 public:
@@ -53,7 +55,7 @@ public:
   ~HaloSnapshot_t()
   {
 // 	Clear();
-	MPI_Type_free(&MPI_HBT_HaloId_t);
+	My_Type_free(&MPI_HBT_HaloId_t);
   }
   void Load(MpiWorker_t & world, int snapshot_index);
   void Clear();

--- a/src/io/apostle_io.h
+++ b/src/io/apostle_io.h
@@ -58,7 +58,7 @@ public:
   }
   ~ApostleReader_t()
   {
-    MPI_Type_free(&MPI_ApostleHeader_t);
+    My_Type_free(&MPI_ApostleHeader_t);
   }
   void LoadSnapshot(MpiWorker_t &world, int snapshotId, vector <Particle_t> &Particles, Cosmology_t &Cosmology);
   void LoadGroups(MpiWorker_t &world, int snapshotId, vector <Halo_t> &Halos);

--- a/src/mpi_wrapper.cpp
+++ b/src/mpi_wrapper.cpp
@@ -43,3 +43,17 @@ void MpiWorker_t::SyncVectorString(vector< string >& x, int root)
       x.push_back(s);
   }
 }
+
+/* 
+   Free an MPI type, but only if MPI has not been finalized.
+   This is for use in object destructors which might be called
+   after MPI has been finalized. If it has, the type has already
+   been freed and we don't need to do anything.
+*/
+void My_Type_free(MPI_Datatype *datatype) {
+
+  int finalized;
+  MPI_Finalized(&finalized);
+  if(!finalized)MPI_Type_free(datatype);
+
+}

--- a/src/mpi_wrapper.h
+++ b/src/mpi_wrapper.h
@@ -222,4 +222,12 @@ void MyBcast(MpiWorker_t &world, InParticleIterator_T InParticleIterator, OutPar
 	}
   }
 }
+
+/* 
+   Free an MPI type, but only if MPI has not been finalized.
+   This is for use in object destructors which might be called
+   after MPI has been finalized. If it has, the type has already
+   been freed and we don't need to do anything.
+*/
+void My_Type_free(MPI_Datatype *datatype);
 #endif

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -113,7 +113,7 @@ public:
   ParticleExchanger_t(MpiWorker_t &world, const ParticleSnapshot_t &snap, vector <Halo_T> &InHalos);
   ~ParticleExchanger_t()
   {
-	MPI_Type_free(&MPI_HBTParticle_t);
+	My_Type_free(&MPI_HBTParticle_t);
   }
   void Exchange();
 };

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -9,6 +9,7 @@
 #include "snapshot_number.h"
 #include "halo.h"
 #include "hdf_wrapper.h"
+#include "mpi_wrapper.h"
 
 enum class SubReaderDepth_t
 {
@@ -226,7 +227,7 @@ public:
   {
 	H5Tclose(H5T_SubhaloInDisk);
 	H5Tclose(H5T_SubhaloInMem);
-	MPI_Type_free(&MPI_HBT_SubhaloShell_t);
+        My_Type_free(&MPI_HBT_SubhaloShell_t);
   }
   string GetSubDir();
   void GetSubFileName(string &filename, int iFile, const string &ftype="Sub");


### PR DESCRIPTION
The subsnap object in HBT.c goes out of scope after MPI_Finalize and its destructor calls MPI_Type_Free. Calling MPI routines after MPI_Finalize is not allowed and with Intel MPI the program aborts with a non-zero exit code and this message:
```
Attempting to use an MPI routine after finalizing MPICH
```
I've tried to fix it by having the destructor check if MPI has been finalized. If it has, we don't need to free the type because it should have already been freed.
